### PR TITLE
[Refactor] Remove URLSessionDataTask param from success / cached callbacks.

### DIFF
--- a/Example/CZNetworkingDemo/ViewController.swift
+++ b/Example/CZNetworkingDemo/ViewController.swift
@@ -24,7 +24,7 @@ class ViewController: UIViewController {
       Self.endpoint,
       success: { (feeds: [Feed]) in
         dbgPrint("Succeed to fetch feeds: \n\(feeds.map { $0.id })")
-    }, failure: { (task, error) in
+    }, failure: { (error) in
       assertionFailure("Failed to fetch feeds. Error - \(error)")
     })
   }  

--- a/Sources/CZNetworking/CZHTTPManager.swift
+++ b/Sources/CZNetworking/CZHTTPManager.swift
@@ -55,21 +55,21 @@ open class CZHTTPManager: NSObject {
                   params: HTTPRequestWorker.Params? = nil,
                   shouldSerializeJson: Bool = true,
                   queuePriority: Operation.QueuePriority = .normal,
-                  success: ((URLSessionDataTask?, Data?) -> Void)? = nil,
+                  success: ((Data?) -> Void)? = nil,
                   failure: HTTPRequestWorker.Failure? = nil,
-                  cached: ((URLSessionDataTask?, Data?) -> Void)? = nil,
+                  cached: ((Data?) -> Void)? = nil,
                   progress: HTTPRequestWorker.Progress? = nil) {
     _GET(urlStr,
          headers: headers,
          params: params,
          shouldSerializeJson: shouldSerializeJson,
          queuePriority: queuePriority,
-         success: { (task, _: Data?, metaData) in
-          success?(task, metaData)
+         success: { (_: Data?, metaData) in
+          success?(metaData)
          },
          failure: failure,
-         cached: cached == nil ? nil : { (task, _, metaData) in
-          cached?(task, metaData)
+         cached: cached == nil ? nil : { (_, metaData) in
+          cached?(metaData)
          },
          progress: progress)
   }
@@ -95,11 +95,11 @@ open class CZHTTPManager: NSObject {
         headers: headers,
         params: params,
         decodeClosure: DataDecodeHelper.codableDecodeClosure(dataKey: dataKey, inferringModel: urlStr as? Model),
-        success: { (task, model, data) in
+        success: { (model, data) in
           success(model, data)
         },
         failure: failure,
-        cached: cached == nil ? nil : { (task, model, data) in
+        cached: cached == nil ? nil : { (model, data) in
           cached?(model, data)
         },
         progress: progress)
@@ -172,11 +172,11 @@ open class CZHTTPManager: NSObject {
         headers: headers,
         params: params,
         decodeClosure: DataDecodeHelper.oneDictionaryableDecodeClosure(dataKey: dataKey, inferringModel: urlStr as? Model),
-        success: { (task, model, data) in
+        success: { (model, data) in
           success(model)
         },
         failure: failure,
-        cached: cached == nil ? nil : { (task, model, data) in
+        cached: cached == nil ? nil : { (model, data) in
           cached?(model)
         },
         progress: progress)
@@ -194,11 +194,11 @@ open class CZHTTPManager: NSObject {
         headers: headers,
         params: params,
         decodeClosure: DataDecodeHelper.manyDictionaryableDecodeClosure(dataKey: dataKey, inferringModel: urlStr as? Model),
-        success: { (task, models, data) in
+        success: { (models, data) in
           success(models)
         },
         failure: failure,
-        cached: cached == nil ? nil : { (task, models, data) in
+        cached: cached == nil ? nil : { (models, data) in
           cached?(models)
         },
         progress: progress)
@@ -219,8 +219,8 @@ open class CZHTTPManager: NSObject {
       urlStr: urlStr,
       headers: headers,
       params: params,
-      success: { (task, model, data) in
-        success?(task, data)
+      success: { (model, data) in
+        success?(data)
       },
       failure: failure,
       progress: progress)
@@ -238,8 +238,8 @@ open class CZHTTPManager: NSObject {
       urlStr: urlStr,
       headers: headers,
       params: params,
-      success: { (task, model, data) in
-        success?(task, data)
+      success: { (model, data) in
+        success?(data)
       },
       failure: failure)
   }
@@ -260,8 +260,8 @@ open class CZHTTPManager: NSObject {
       urlStr: urlStr,
       headers: headers,
       params: params,
-      success: { (task, model, data) in
-        success?(task, data)
+      success: { (model, data) in
+        success?(data)
       },
       failure: failure,
       progress: progress)
@@ -278,9 +278,9 @@ private extension CZHTTPManager {
                            shouldSerializeJson: Bool = true,
                            queuePriority: Operation.QueuePriority = .normal,
                            decodeClosure: HTTPRequestWorker.DecodeClosure? = nil,
-                           success: ((URLSessionDataTask?, Model, Data?) -> Void)? = nil,
+                           success: ((Model, Data?) -> Void)? = nil,
                            failure: HTTPRequestWorker.Failure? = nil,
-                           cached: ((URLSessionDataTask?, Model, Data?) -> Void)? = nil,
+                           cached: ((Model, Data?) -> Void)? = nil,
                            progress: HTTPRequestWorker.Progress? = nil) {
     startOperationGeneric(
       .GET,
@@ -333,17 +333,17 @@ private extension CZHTTPManager {
                                     shouldSerializeJson: Bool = true,
                                     queuePriority: Operation.QueuePriority = .normal,
                                     decodeClosure: HTTPRequestWorker.DecodeClosure? = nil,
-                                    success: ((URLSessionDataTask?, Model, Data?) -> Void)? = nil,
+                                    success: ((Model, Data?) -> Void)? = nil,
                                     failure: HTTPRequestWorker.Failure? = nil,
-                                    cached: ((URLSessionDataTask?, Model, Data?) -> Void)? = nil,
+                                    cached: ((Model, Data?) -> Void)? = nil,
                                     progress: HTTPRequestWorker.Progress? = nil) {
-    typealias Completion = (URLSessionDataTask?, Model, Data?) -> Void
-    let completionHandler = { (completion: Completion?, task: URLSessionDataTask?, model: Any?, data: Data?) in
+    typealias Completion = (Model, Data?) -> Void
+    let completionHandler = { (completion: Completion?, model: Any?, data: Data?) in
       guard let model = (model as? Model).assertIfNil else {
-        failure?(nil, CZNetError.parse)
+        failure?(CZNetError.parse)
         return
       }
-      completion?(task, model, data)
+      completion?(model, data)
     }
 
     startOperation(
@@ -354,12 +354,12 @@ private extension CZHTTPManager {
       shouldSerializeJson: shouldSerializeJson,
       queuePriority: queuePriority,
       decodeClosure:decodeClosure,
-      success: { (task, model, data) in
-        completionHandler(success, task, model, data)
+      success: { (model, data) in
+        completionHandler(success, model, data)
       },
       failure: failure,
-      cached: cached == nil ? nil : { (task, model, data) in
-        completionHandler(cached, task, model, data)
+      cached: cached == nil ? nil : { (model, data) in
+        completionHandler(cached, model, data)
       },
       progress: progress)
   }

--- a/Sources/CZNetworking/HTTPRequestWorker.swift
+++ b/Sources/CZNetworking/HTTPRequestWorker.swift
@@ -15,8 +15,8 @@ open class HTTPRequestWorker: ConcurrentBlockOperation {
     case formUrlencoded
   }
 
-  public typealias Success = (URLSessionDataTask?, Data?) -> Void
-  public typealias Failure = (URLSessionDataTask?, Error) -> Void
+  public typealias Success = (Data?) -> Void
+  public typealias Failure = (Error) -> Void
   /// Progress closure: (currSize, totalSize, downloadURL)
   public typealias Progress = (Int64, Int64, URL) -> Void
   public typealias Cached = Success
@@ -24,9 +24,9 @@ open class HTTPRequestWorker: ConcurrentBlockOperation {
   public typealias DecodeClosure = (Data?) -> Any?
   
   /// - Note: Internal Only!
-  /// Internal Success closure: (task, model, data).
+  /// Internal Success closure: (model, data).
   /// `model` is decoded with `decodeClosure` if `decodeClosure` isn't nil.
-  public typealias InternalSuccess = (URLSessionDataTask?, Any?, Data?) -> Void
+  public typealias InternalSuccess = (Any?, Data?) -> Void
   public typealias InternalCached = InternalSuccess
   
   private var success: InternalSuccess?
@@ -95,7 +95,7 @@ open class HTTPRequestWorker: ConcurrentBlockOperation {
       let cached = cached,
       let cachedData = httpCache?.readData(forKey: httpCacheKey, shouldDeserializeJsonData: false) as? Data {
       MainQueueScheduler.async { [weak self] in
-        cached(self?.dataTask, cachedData, cachedData)
+        cached(cachedData, cachedData)
       }
     }
     
@@ -270,7 +270,7 @@ extension HTTPRequestWorker: URLSessionDataDelegate {
     
     MainQueueScheduler.async { [weak self] in
       guard let `self` = self else {return}
-      self.success?(task as? URLSessionDataTask, dataOrModel, self.receivedData)
+      self.success?(dataOrModel, self.receivedData)
     }
     
   }
@@ -289,9 +289,7 @@ private extension HTTPRequestWorker {
       return
     }
     MainQueueScheduler.async { [weak self] in
-      self?.failure?(nil, error)
+      self?.failure?(error)
     }
   }
 }
-
-

--- a/Tests/CZNetworkingTests/CZHTTPManagerTests.swift
+++ b/Tests/CZNetworkingTests/CZHTTPManagerTests.swift
@@ -4,7 +4,7 @@ import CZTestUtils
 @testable import CZNetworking
 
 final class CZHTTPManagerTests: XCTestCase {
-  public typealias GetRequestSuccess = (URLSessionDataTask?, Data?) -> Void
+  public typealias GetRequestSuccess = (Data?) -> Void
   
   private enum Constant {
     static let timeOut: TimeInterval = 30
@@ -58,7 +58,7 @@ final class CZHTTPManagerTests: XCTestCase {
     // Stub MockData.
     CZHTTPManager.stubMockData(dict: mockDataMap)
     
-    CZHTTPManager.shared.GET(MockData.urlForGet.absoluteString, success: { (_, data) in
+    CZHTTPManager.shared.GET(MockData.urlForGet.absoluteString, success: { (data) in
       let res: [String: AnyHashable]? = CZHTTPJsonSerializer.deserializedObject(with: data)
       XCTAssert(res == MockData.dictionary, "Actual result = \(res), Expected result = \(MockData.dictionary)")
       expectation.fulfill()
@@ -78,12 +78,12 @@ final class CZHTTPManagerTests: XCTestCase {
     let mockData = CZHTTPJsonSerializer.jsonData(with: MockData.dictionary)!
     let mockDataMap = [MockData.urlForGet: mockData]
     
-    let success: GetRequestSuccess = { (_, data) in
+    let success: GetRequestSuccess = { (data) in
       let res: [String: AnyHashable]? = CZHTTPJsonSerializer.deserializedObject(with: data)
       XCTAssert(res == MockData.dictionary, "Actual result = \(res), Expected result = \(MockData.dictionary)")
     }
     
-    let cached: GetRequestSuccess = { (_, data) in
+    let cached: GetRequestSuccess = { (data) in
       let res: [String: AnyHashable]? = CZHTTPJsonSerializer.deserializedObject(with: data)
       XCTAssert(res == MockData.dictionary, "Actual result = \(res), Expected result = \(MockData.dictionary)")
     }
@@ -102,8 +102,8 @@ final class CZHTTPManagerTests: XCTestCase {
       CZHTTPManager.shared.GET(
         MockData.urlForGet.absoluteString,
         success: success,
-        cached: { (task, data) in
-          cached(task, data)
+        cached: { (data) in
+          cached(data)
           // Fullfill the expectatation.
           expectation.fulfill()
       })
@@ -123,7 +123,7 @@ final class CZHTTPManagerTests: XCTestCase {
     let mockData = CZHTTPJsonSerializer.jsonData(with: MockData.dictionary)!
     let mockDataMap = [MockData.urlForGet: mockData]
     
-    let success: GetRequestSuccess = { (_, data) in
+    let success: GetRequestSuccess = { (data) in
       let res: [String: AnyHashable]? = CZHTTPJsonSerializer.deserializedObject(with: data)
       XCTAssert(res == MockData.dictionary, "Actual result = \(res), Expected result = \(MockData.dictionary)")
     }
@@ -141,11 +141,11 @@ final class CZHTTPManagerTests: XCTestCase {
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
       CZHTTPManager.shared.GET(
         MockData.urlForGet.absoluteString,
-        success: { (task, data) in
+        success: { (data) in
           // Fullfill the expectatation.
           expectation.fulfill()
         },
-        cached: { (task, data) in
+        cached: { (data) in
           XCTFail("Second time `cached` shouldn't be called - because the first time `cached` wasn't set.")
       })
     }
@@ -164,12 +164,12 @@ final class CZHTTPManagerTests: XCTestCase {
     let mockData = CZHTTPJsonSerializer.jsonData(with: MockData.dictionary)!
     let mockDataMap = [MockData.urlForGet: mockData]
     
-    let success: GetRequestSuccess = { (_, data) in
+    let success: GetRequestSuccess = { (data) in
       let res: [String: AnyHashable]? = CZHTTPJsonSerializer.deserializedObject(with: data)
       XCTAssert(res == MockData.dictionary, "Actual result = \(res), Expected result = \(MockData.dictionary)")
     }
     
-    let cached: GetRequestSuccess = { (_, data) in
+    let cached: GetRequestSuccess = { (data) in
       let res: [String: AnyHashable]? = CZHTTPJsonSerializer.deserializedObject(with: data)
       XCTAssert(res == MockData.dictionary, "Actual result = \(res), Expected result = \(MockData.dictionary)")
     }
@@ -184,8 +184,8 @@ final class CZHTTPManagerTests: XCTestCase {
       dispatchGroup.enter()
       CZHTTPManager.shared.GET(
         MockData.urlForGet.absoluteString,
-        success: { (task, data) in
-          success(task, data)
+        success: { (data) in
+          success(data)
           self._executionSuccessCount.threadLock {
             $0 = $0 + 1
             print("Success count = \($0)")


### PR DESCRIPTION

Simplify request APIs: 
- `task` in callbacks aren't used by callers.